### PR TITLE
Introducing unit tests.

### DIFF
--- a/instance-scheduler/main.go
+++ b/instance-scheduler/main.go
@@ -120,7 +120,6 @@ func stopInstance(client *ec2.Client, instanceId string) {
 	}
 }
 
-// can be tested, ec2 client can be passed, but instead of using ec2.client use ec2iface
 func startInstance(client *ec2.Client, instanceId string) {
 	input := &ec2.StartInstancesInput{
 		InstanceIds: []string{
@@ -145,7 +144,6 @@ func startInstance(client *ec2.Client, instanceId string) {
 	}
 }
 
-// can be tested, ec2 client can be passed, but instead of using ec2.client use ec2iface
 func stopStartTestInstancesInMemberAccount(client *ec2.Client, action string) {
 	input := &ec2.DescribeInstancesInput{}
 

--- a/instance-scheduler/main.go
+++ b/instance-scheduler/main.go
@@ -77,7 +77,7 @@ func getSecret(client ISecretManagerGetSecretValue, secretId string) string {
 	return *result.SecretString
 }
 
-func getNonProductionAccounts(secretId string, environments string, skipAccountNames string) map[string]string {
+func getNonProductionAccounts(environments string, skipAccountNames string) map[string]string {
 	accounts := make(map[string]string)
 
 	var allAccounts map[string]interface{}
@@ -285,7 +285,7 @@ func handler(ctx context.Context, request InstanceSchedulingRequest) (events.API
 	secretsManagerClient := secretsmanager.NewFromConfig(cfg)
 	environments := getSecret(secretsManagerClient, secretId)
 
-	accounts := getNonProductionAccounts(secretId, environments, skipAccounts)
+	accounts := getNonProductionAccounts(environments, skipAccounts)
 	memberAccountNames := []string{}
 	nonMemberAccountNames := []string{}
 	for accName, accId := range accounts {

--- a/instance-scheduler/main_test.go
+++ b/instance-scheduler/main_test.go
@@ -5,25 +5,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"strconv"
 	"testing"
 )
-
-//func TestGetNonProductionAccounts(t *testing.T) {
-//	// Load the Shared AWS Configuration (~/.aws/config)
-//	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion("eu-west-2"))
-//	if err != nil {
-//		log.Fatal(err)
-//	}
-//	got := getNonProductionAccounts(cfg, "oasys-development,apex-development,data-and-insights-wepi-development,xhibit-portal-development,nomis-preproduction,testing-test,oasys-preproduction,tariff-development,mlra-development,nomis-development,example-development,performance-hub-preproduction,xhibit-portal-preproduction,delius-iaps-development,performance-hub-development,ppud-development,refer-monitor-development,digital-prison-reporting-development,oasys-test,equip-development,threat-and-vulnerability-mgmt-development,nomis-test,ccms-ebs-development,maatdb-development")
-//	want := map[string]string{
-//		"something": "something",
-//	}
-//	fmt.Println(got)
-//	fmt.Println("")
-//	fmt.Println(want)
-//
-//}
 
 type mockGetParameter func(ctx context.Context, params *ssm.GetParameterInput, optFns ...func(*ssm.Options)) (*ssm.GetParameterOutput, error)
 
@@ -49,19 +34,21 @@ func TestGetParameter(t *testing.T) {
 					}
 
 					return &ssm.GetParameterOutput{
-						Parameter: aws.String("test-parameter-arn"),
-					}.Value, nil
+						Parameter: &types.Parameter{
+							Value: aws.String("test-parameter-value"),
+						},
+					}, nil
 				})
 			},
 			name: "test-parameter-name",
-			want: "test-parameter-arn",
+			want: "test-parameter-value",
 		},
 	}
 
 	for i, subtest := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			secret := getParameter(subtest.client(t), subtest.name)
-			if want, got := subtest.want, secret; want != got {
+			parameter := getParameter(subtest.client(t), subtest.name)
+			if want, got := subtest.want, parameter; want != got {
 				t.Errorf("want %v, got %v", subtest.want, got)
 			}
 		})

--- a/instance-scheduler/main_test.go
+++ b/instance-scheduler/main_test.go
@@ -98,7 +98,7 @@ func TestGetSecret(t *testing.T) {
 	}
 }
 
-func TestHandlerFunction(t *testing.T) {
+func TestHandler(t *testing.T) {
 	t.Run("Testing the lambda function", func(t *testing.T) {
 		_, err := handler(context.TODO(), InstanceSchedulingRequest{Action: "Test"})
 		if err != nil {

--- a/instance-scheduler/main_test.go
+++ b/instance-scheduler/main_test.go
@@ -2,10 +2,116 @@ package main
 
 import (
 	"context"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"strconv"
 	"testing"
 )
 
-func TestHandler(t *testing.T) {
+//func TestGetNonProductionAccounts(t *testing.T) {
+//	// Load the Shared AWS Configuration (~/.aws/config)
+//	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion("eu-west-2"))
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//	got := getNonProductionAccounts(cfg, "oasys-development,apex-development,data-and-insights-wepi-development,xhibit-portal-development,nomis-preproduction,testing-test,oasys-preproduction,tariff-development,mlra-development,nomis-development,example-development,performance-hub-preproduction,xhibit-portal-preproduction,delius-iaps-development,performance-hub-development,ppud-development,refer-monitor-development,digital-prison-reporting-development,oasys-test,equip-development,threat-and-vulnerability-mgmt-development,nomis-test,ccms-ebs-development,maatdb-development")
+//	want := map[string]string{
+//		"something": "something",
+//	}
+//	fmt.Println(got)
+//	fmt.Println("")
+//	fmt.Println(want)
+//
+//}
+
+type mockGetParameter func(ctx context.Context, params *ssm.GetParameterInput, optFns ...func(*ssm.Options)) (*ssm.GetParameterOutput, error)
+
+func (m mockGetParameter) GetParameter(ctx context.Context, params *ssm.GetParameterInput, optFns ...func(*ssm.Options)) (*ssm.GetParameterOutput, error) {
+	return m(ctx, params, optFns...)
+}
+
+func TestGetParameter(t *testing.T) {
+	tests := []struct {
+		client func(t *testing.T) ISSMGetParameter
+		name   string
+		want   string
+	}{
+		{
+			client: func(t *testing.T) ISSMGetParameter {
+				return mockGetParameter(func(ctx context.Context, params *ssm.GetParameterInput, optFns ...func(*ssm.Options)) (*ssm.GetParameterOutput, error) {
+					t.Helper()
+					if params.Name == nil {
+						t.Fatal("want Name to not be nil")
+					}
+					if want, got := "test-parameter-name", *params.Name; want != got {
+						t.Errorf("want %v, got %v", want, got)
+					}
+
+					return &ssm.GetParameterOutput{
+						Parameter: aws.String("test-parameter-arn"),
+					}.Value, nil
+				})
+			},
+			name: "test-parameter-name",
+			want: "test-parameter-arn",
+		},
+	}
+
+	for i, subtest := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			secret := getParameter(subtest.client(t), subtest.name)
+			if want, got := subtest.want, secret; want != got {
+				t.Errorf("want %v, got %v", subtest.want, got)
+			}
+		})
+	}
+}
+
+type mockGetSecretValue func(ctx context.Context, params *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
+
+func (m mockGetSecretValue) GetSecretValue(ctx context.Context, params *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+	return m(ctx, params, optFns...)
+}
+
+func TestGetSecret(t *testing.T) {
+	cases := []struct {
+		client   func(t *testing.T) ISecretManagerGetSecretValue
+		secretId string
+		want     string
+	}{
+		{
+			client: func(t *testing.T) ISecretManagerGetSecretValue {
+				return mockGetSecretValue(func(ctx context.Context, params *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+					t.Helper()
+					if params.SecretId == nil {
+						t.Fatal("want SecretId to not be nil")
+					}
+					if want, got := "test-mod-platform-account-development", *params.SecretId; want != got {
+						t.Errorf("want %v, got %v", want, got)
+					}
+
+					return &secretsmanager.GetSecretValueOutput{
+						SecretString: aws.String("123456789012"),
+					}, nil
+				})
+			},
+			secretId: "test-mod-platform-account-development",
+			want:     "123456789012",
+		},
+	}
+
+	for i, subtest := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			secret := getSecret(subtest.client(t), subtest.secretId)
+			if want, got := subtest.want, secret; want != got {
+				t.Errorf("want %v, got %v", subtest.want, got)
+			}
+		})
+	}
+}
+
+func TestHandlerFunction(t *testing.T) {
 	t.Run("Testing the lambda function", func(t *testing.T) {
 		_, err := handler(context.TODO(), InstanceSchedulingRequest{Action: "Test"})
 		if err != nil {


### PR DESCRIPTION
This PR is to enable API mocking for use in unit tests and to provide an example on how to implement such unit tests.

The above has been achieved through:
1. Introducing aws client's interfaces so that it is possible to mock their APIs (in main.go)
2. Passing client's interfaces into functions rather than defining them inside the functions.
3. Introducing simple unit tests for getSecret and getParameter functions in main_test.go 

More unit tests and more code refactoring will be needed in the future PRs for better code coverage. This is just a mechanism and an example of how it can be achieved.