### PR TITLE
Added integration test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,4 @@ Run Tests
 2. [How the original Go SAM project was created](sam-init.md)
 3. [AWS Serverless Application Model](https://aws.amazon.com/serverless/sam/)
 4. [AWS Serverless Application Repository](https://aws.amazon.com/serverless/serverlessrepo/)
+5. [Terraform module for deployment of the lambda](https://github.com/ministryofjustice/modernisation-platform-terraform-lambda-function)

--- a/instance-scheduler/main_int_test.go
+++ b/instance-scheduler/main_int_test.go
@@ -39,11 +39,12 @@ func TestHandler(t *testing.T) {
 				assert.False(t, strings.HasSuffix(accountName, "-preproduction"), fmt.Sprintf("Non-member account %v was found with suffix '-preproduction'. Accounts with such suffix are member accounts.", accountName))
 			}
 		}
-		assert.Greater(t, res.ActedUpon, 20, "Number of instances acted upon seems too low")
-		assert.Less(t, res.ActedUpon, 100, "Number of instances acted upon seems too high")
-		assert.Greater(t, res.Skipped, 0, "Number of skipped instances seems too low")
-		assert.Less(t, res.Skipped, 50, "Number of skipped instances seems too high")
-		assert.Greater(t, res.SkippedAutoScaled, 20, "Number of skipped instances that belong to an Auto Scaling group seems too low")
-		assert.Less(t, res.SkippedAutoScaled, 100, "Number of skipped instances that belong to an Auto Scaling group seems too high")
+		addMsg := "Please manually check the Instance Scheduler logs and verify this is reasonable. If it is reasonable, modify and adjust this test accordingly."
+		assert.Greater(t, res.ActedUpon, 20, fmt.Sprintf("Number of instances acted upon seems too low. %v", addMsg))
+		assert.Less(t, res.ActedUpon, 100, fmt.Sprintf("Number of instances acted upon seems too high. %v", addMsg))
+		assert.Greater(t, res.Skipped, 0, fmt.Sprintf("Number of skipped instances seems too low. %v", addMsg))
+		assert.Less(t, res.Skipped, 50, fmt.Sprintf("Number of skipped instances seems too high. %v", addMsg))
+		assert.Greater(t, res.SkippedAutoScaled, 20, fmt.Sprintf("Number of skipped instances that belong to an Auto Scaling group seems too low. %v", addMsg))
+		assert.Less(t, res.SkippedAutoScaled, 100, fmt.Sprintf("Number of skipped instances that belong to an Auto Scaling group seems too high. %v", addMsg))
 	})
 }

--- a/instance-scheduler/main_int_test.go
+++ b/instance-scheduler/main_int_test.go
@@ -30,7 +30,7 @@ func TestHandler(t *testing.T) {
 				strings.HasSuffix(accountName, "-test") ||
 				strings.HasSuffix(accountName, "-preproduction"), fmt.Sprintf("Unexpected suffix in member account %v", accountName))
 		}
-		assert.NotEmpty(t, res.NonMemberAccountNames, "No member account was found")
+		assert.NotEmpty(t, res.NonMemberAccountNames, "No non-member account was found")
 		for _, accountName := range res.NonMemberAccountNames {
 			assert.False(t, strings.HasSuffix(accountName, "-production"), fmt.Sprintf("Production account %v was found in the list of non-member accounts. Production accounts should be skipped.", accountName))
 			if !strings.HasPrefix(accountName, "core-vpc-") {

--- a/instance-scheduler/main_int_test.go
+++ b/instance-scheduler/main_int_test.go
@@ -5,21 +5,45 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"os"
 	"strings"
 	"testing"
 )
 
 func TestHandler(t *testing.T) {
 	t.Run("Test request", func(t *testing.T) {
+		// Accounts mi-platform-development and analytical-platform-data-development cause the main_int_test.go to fail because they appear
+		// to lack the InstanceSchedulerAccess role. For now, I have excluded them from the test via the env variable INSTANCE_SCHEDULING_SKIP_ACCOUNTS
+		os.Setenv("INSTANCE_SCHEDULING_SKIP_ACCOUNTS", "mi-platform-development,analytical-platform-data-development,")
+
 		result, err := handler(context.TODO(), InstanceSchedulingRequest{Action: "Test"})
 		if err != nil {
 			t.Fatalf("Failed to run lambda's handler: %v", err)
 		}
 		res := InstanceSchedulingResponse{}
 		json.Unmarshal([]byte(result.Body), &res)
+		assert.Equal(t, res.Action, "Test", "Response action does not match requested action")
 		assert.NotEmpty(t, res.MemberAccountNames, "No member account was found")
 		for _, accountName := range res.MemberAccountNames {
 			assert.False(t, strings.HasSuffix(accountName, "-production"), fmt.Sprintf("Production account %v was found in the list of member accounts. Production accounts should be skipped.", accountName))
+			assert.True(t, strings.HasSuffix(accountName, "-development") ||
+				strings.HasSuffix(accountName, "-test") ||
+				strings.HasSuffix(accountName, "-preproduction"), fmt.Sprintf("Unexpected suffix in member account %v", accountName))
 		}
+		assert.NotEmpty(t, res.NonMemberAccountNames, "No member account was found")
+		for _, accountName := range res.NonMemberAccountNames {
+			assert.False(t, strings.HasSuffix(accountName, "-production"), fmt.Sprintf("Production account %v was found in the list of non-member accounts. Production accounts should be skipped.", accountName))
+			if !strings.HasPrefix(accountName, "core-vpc-") {
+				assert.False(t, strings.HasSuffix(accountName, "-development"), fmt.Sprintf("Non-member account %v was found with suffix '-development'. Accounts with such suffix are member accounts.", accountName))
+				assert.False(t, strings.HasSuffix(accountName, "-test"), fmt.Sprintf("Non-member account %v was found with suffix '-test'. Accounts with such suffix are member accounts.", accountName))
+				assert.False(t, strings.HasSuffix(accountName, "-preproduction"), fmt.Sprintf("Non-member account %v was found with suffix '-preproduction'. Accounts with such suffix are member accounts.", accountName))
+			}
+		}
+		assert.Greater(t, res.ActedUpon, 20, "Number of instances acted upon seems too low")
+		assert.Less(t, res.ActedUpon, 100, "Number of instances acted upon seems too high")
+		assert.Greater(t, res.Skipped, 0, "Number of skipped instances seems too low")
+		assert.Less(t, res.Skipped, 50, "Number of skipped instances seems too high")
+		assert.Greater(t, res.SkippedAutoScaled, 20, "Number of skipped instances that belong to an Auto Scaling group seems too low")
+		assert.Less(t, res.SkippedAutoScaled, 100, "Number of skipped instances that belong to an Auto Scaling group seems too high")
 	})
 }

--- a/instance-scheduler/main_int_test.go
+++ b/instance-scheduler/main_int_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestHandler(t *testing.T) {
 	t.Run("Test request", func(t *testing.T) {
-		// Accounts mi-platform-development and analytical-platform-data-development cause the main_int_test.go to fail because they appear
-		// to lack the InstanceSchedulerAccess role. For now, I have excluded them from the test via the env variable INSTANCE_SCHEDULING_SKIP_ACCOUNTS
+		// Accounts mi-platform-development and analytical-platform-data-development cause the main_int_test.go to fail because they are non-member accounts
+		// lacking the InstanceSchedulerAccess role, but they have the '-development' suffix typically present in member accounts.
 		os.Setenv("INSTANCE_SCHEDULING_SKIP_ACCOUNTS", "mi-platform-development,analytical-platform-data-development,")
 
 		result, err := handler(context.TODO(), InstanceSchedulingRequest{Action: "Test"})

--- a/template.yaml
+++ b/template.yaml
@@ -35,7 +35,7 @@ Resources:
             Method: GET
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
-          INSTANCE_SCHEDULING_SKIP_ACCOUNTS: nomis-preproduction,
+          INSTANCE_SCHEDULING_SKIP_ACCOUNTS: nomis-preproduction,mi-platform-development,analytical-platform-data-development,
     Metadata:
       Dockerfile: Dockerfile
       DockerContext: ./instance-scheduler

--- a/template.yaml
+++ b/template.yaml
@@ -35,7 +35,7 @@ Resources:
             Method: GET
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
-          INSTANCE_SCHEDULING_SKIP_ACCOUNTS: oasys-development,apex-development,data-and-insights-wepi-development,xhibit-portal-development,nomis-preproduction,testing-test,oasys-preproduction,tariff-development,mlra-development,nomis-development,example-development,performance-hub-preproduction,xhibit-portal-preproduction,delius-iaps-development,performance-hub-development,ppud-development,refer-monitor-development,digital-prison-reporting-development,oasys-test,equip-development,threat-and-vulnerability-mgmt-development,nomis-test,ccms-ebs-development,maatdb-development,
+          INSTANCE_SCHEDULING_SKIP_ACCOUNTS: nomis-preproduction,
     Metadata:
       Dockerfile: Dockerfile
       DockerContext: ./instance-scheduler

--- a/template.yaml
+++ b/template.yaml
@@ -35,7 +35,8 @@ Resources:
             Method: GET
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
-          INSTANCE_SCHEDULING_SKIP_ACCOUNTS: nomis-preproduction,mi-platform-development,analytical-platform-data-development,
+          # Only nomis-preproduction is a member account having the InstanceSchedulerAccess role
+          INSTANCE_SCHEDULING_SKIP_ACCOUNTS: nomis-preproduction,mi-platform-development,analytical-platform-data-development,bichard7-test-next,bichard7-sandbox-shared,core-vpc-development,bichard7-sandbox-a,bichard7-shared,bichard7-test-current,bichard7-sandbox-c,core-vpc-sandbox,core-vpc-test,bichard7-sandbox-b,core-vpc-preproduction,core-sandbox-dev,
     Metadata:
       Dockerfile: Dockerfile
       DockerContext: ./instance-scheduler


### PR DESCRIPTION
- Added integration test cases: response action, non-member accounts, instance counts
- Accounts mi-platform-development and analytical-platform-data-development cause the main_int_test.go to fail because they appear to lack the InstanceSchedulerAccess role. For now, I have excluded them from the integration test main_int_test.go via the env variable INSTANCE_SCHEDULING_SKIP_ACCOUNTS
- Aligned INSTANCE_SCHEDULING_SKIP_ACCOUNTS env variable with terraform deployment
- Added terraform module deployment to references in README.md