### PR TITLE
Validating action for empty strings and invalid values.

### DIFF
--- a/instance-scheduler/main.go
+++ b/instance-scheduler/main.go
@@ -157,6 +157,13 @@ type IEC2InstancesAPI interface {
 
 func stopStartTestInstancesInMemberAccount(client IEC2InstancesAPI, action string) *InstanceCount {
 	count := &InstanceCount{actedUpon: 0, skipped: 0, skippedAutoScaled: 0}
+	switch action {
+	case "test", "start", "stop":
+		break
+	default:
+		log.Print("ERROR: Invalid Action. Must be one of 'start' 'stop' 'test'")
+		return count
+	}
 	result, err := client.DescribeInstances(context.TODO(), &ec2.DescribeInstancesInput{})
 
 	if err != nil {


### PR DESCRIPTION
Related Issue: https://github.com/ministryofjustice/modernisation-platform/issues/2640

Fixing test failues 1:

```
Run Unit Tests of the instance scheduler and see the results of the following test cases:
testing empty action input
testing invalid action input

```
