### PR TITLE
Fixing the causes of failure for the stop action unit test

### DIFF
--- a/instance-scheduler/Dockerfile
+++ b/instance-scheduler/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN yum install -y golang
 RUN go env -w GOPROXY=direct
 
-RUN CGO_ENABLED=0 go build \
+RUN GOPROXY=proxy.golang.org CGO_ENABLED=0 go build \
     -o /instance-scheduler .
 
 FROM public.ecr.aws/lambda/go:1

--- a/instance-scheduler/go.mod
+++ b/instance-scheduler/go.mod
@@ -3,7 +3,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.17.1
 	github.com/aws/aws-sdk-go-v2/config v1.18.3
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.3
-	github.com/aws/aws-sdk-go-v2/service/ec2 v1.72.1
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.74.0
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.16.8
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.33.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.17.5

--- a/instance-scheduler/go.sum
+++ b/instance-scheduler/go.sum
@@ -14,8 +14,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.19 h1:oRHDrwCTVT8ZXi4sr9
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.19/go.mod h1:6Q0546uHDp421okhmmGfbxzq2hBqbXFNpi4k+Q1JnQA=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.26 h1:Mza+vlnZr+fPKFKRq/lKGVvM6B/8ZZmNdEopOwSQLms=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.26/go.mod h1:Y2OJ+P+MC1u1VKnavT+PshiEuGPyh/7DqxoDNij4/bg=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.72.1 h1:iR8DtI9Jc9sMdOsvjiu6rs5jH+9csW88elgwpEMP8TU=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.72.1/go.mod h1:zul71QqzR4D1a90/5FloZiAnZ1CtuIjVH7R9MP997+A=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.74.0 h1:5MCRd9q1yrGoRdYZDxK6y048VNmQ6gKLdCFr+TZsvTY=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.74.0/go.mod h1:zul71QqzR4D1a90/5FloZiAnZ1CtuIjVH7R9MP997+A=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.19 h1:GE25AWCdNUPh9AOJzI9KIJnja7IwUc1WyUqz/JTyJ/I=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.19/go.mod h1:02CP6iuYP+IVnBX5HULVdSAku/85eHB2Y9EsFhrkEwU=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.16.8 h1:Zw48FHykP40fKMxPmagkuzklpEuDPLhvUjKP8Ygrds0=

--- a/instance-scheduler/main_test.go
+++ b/instance-scheduler/main_test.go
@@ -2,15 +2,16 @@ package main
 
 import (
 	"context"
+	"reflect"
+	"strconv"
+	"testing"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2type "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
-	"reflect"
-	"strconv"
-	"testing"
 )
 
 type mockGetParameter func(ctx context.Context, params *ssm.GetParameterInput, optFns ...func(*ssm.Options)) (*ssm.GetParameterOutput, error)
@@ -274,7 +275,7 @@ func TestStopStartTestInstancesInMemberAccount(t *testing.T) {
 										},
 									},
 								},
-								// instance-scheduling = skip-auto-stop, therefore skip auto stop, but not test, acted upon: 1
+								// instance-scheduling = skip-auto-stop, therefore skip auto stop, but not test, skipped: 1
 								{
 									InstanceId: aws.String("i-1265579989"),
 									Tags: []ec2type.Tag{
@@ -284,7 +285,7 @@ func TestStopStartTestInstancesInMemberAccount(t *testing.T) {
 										},
 									},
 								},
-								// instance-scheduling = skip-auto-start, therefore skip auto start, but not test, acted upon: 1
+								// instance-scheduling = skip-auto-start, therefore skip auto start, but not test, skipped: 1
 								{
 									InstanceId: aws.String("i-9262279981"),
 									Tags: []ec2type.Tag{
@@ -300,7 +301,7 @@ func TestStopStartTestInstancesInMemberAccount(t *testing.T) {
 				},
 			},
 			action:        "Test",
-			expectedCount: InstanceCount{6, 1, 2},
+			expectedCount: InstanceCount{4, 3, 2},
 		},
 		{
 			testTitle: "testing Stop action",
@@ -312,7 +313,7 @@ func TestStopStartTestInstancesInMemberAccount(t *testing.T) {
 							Instances: []ec2type.Instance{
 								// aws:autoscaling:groupName is set, therefore skip scheduling, skipped auto scaled: 1
 								{
-									InstanceId: aws.String("i-6567788909"),
+									InstanceId: aws.String("i-6567788010"),
 									Tags: []ec2type.Tag{
 										{
 											Key:   aws.String("aws:autoscaling:groupName"),
@@ -322,7 +323,7 @@ func TestStopStartTestInstancesInMemberAccount(t *testing.T) {
 								},
 								// instance-scheduling = default, therefore schedule an instance, acted upon: 1
 								{
-									InstanceId: aws.String("i-6562278909"),
+									InstanceId: aws.String("i-6562278100"),
 									Tags: []ec2type.Tag{
 										{
 											Key:   aws.String("instance-scheduling"),
@@ -337,7 +338,7 @@ func TestStopStartTestInstancesInMemberAccount(t *testing.T) {
 							Instances: []ec2type.Instance{
 								// both instance-scheduling and aws:autoscaling:groupName tags are set, skip scheduling due to autoscaling, skipped auto scaled: 1
 								{
-									InstanceId: aws.String("i-6562788989"),
+									InstanceId: aws.String("i-6562788010"),
 									Tags: []ec2type.Tag{
 										{
 											Key:   aws.String("aws:autoscaling:groupName"),
@@ -351,11 +352,11 @@ func TestStopStartTestInstancesInMemberAccount(t *testing.T) {
 								},
 								// no instance-scheduling and no aws:autoscaling:groupName tags, therefore schedule an instance, acted upon: 1
 								{
-									InstanceId: aws.String("i-6562279989"),
+									InstanceId: aws.String("i-6562279100"),
 								},
 								// instance-scheduling = skip-scheduling, therefore skip scheduling, skipped: 1
 								{
-									InstanceId: aws.String("i-2162279989"),
+									InstanceId: aws.String("i-2162279001"),
 									Tags: []ec2type.Tag{
 										{
 											Key:   aws.String("instance-scheduling"),
@@ -365,7 +366,7 @@ func TestStopStartTestInstancesInMemberAccount(t *testing.T) {
 								},
 								// instance-scheduling is set to an empty string, therefore ignore the tag and auto schedule, acted upon: 1
 								{
-									InstanceId: aws.String("i-7862279989"),
+									InstanceId: aws.String("i-7862279100"),
 									Tags: []ec2type.Tag{
 										{
 											Key:   aws.String("instance-scheduling"),
@@ -375,7 +376,7 @@ func TestStopStartTestInstancesInMemberAccount(t *testing.T) {
 								},
 								// instance-scheduling = "invalid-value", therefore ignore the tag and auto schedule, acted upon: 1
 								{
-									InstanceId: aws.String("i-7863371234"),
+									InstanceId: aws.String("i-7863371100"),
 									Tags: []ec2type.Tag{
 										{
 											Key:   aws.String("instance-scheduling"),
@@ -385,7 +386,7 @@ func TestStopStartTestInstancesInMemberAccount(t *testing.T) {
 								},
 								// instance-scheduling = skip-auto-stop, therefore skip auto stop, skipped: 1
 								{
-									InstanceId: aws.String("i-1265579989"),
+									InstanceId: aws.String("i-1265579001"),
 									Tags: []ec2type.Tag{
 										{
 											Key:   aws.String("instance-scheduling"),
@@ -395,7 +396,7 @@ func TestStopStartTestInstancesInMemberAccount(t *testing.T) {
 								},
 								// instance-scheduling = skip-auto-start, therefore skip auto start, but not stop, acted upon: 1
 								{
-									InstanceId: aws.String("i-9262279981"),
+									InstanceId: aws.String("i-9262279100"),
 									Tags: []ec2type.Tag{
 										{
 											Key:   aws.String("instance-scheduling"),


### PR DESCRIPTION
Relevant Issue: https://github.com/ministryofjustice/modernisation-platform/issues/2640

* Adding a `else` block that actions an instance if the instance-scheduler tag is absent, has an invalid value, an empty value or `default` to align with the [user guidance on instance 
scheduling](https://user-guide.modernisation-platform.service.justice.gov.uk/concepts/environments/instance-scheduling.html#feature-description:~:text=default%20%2D%20Automatically%20stop%20the%20instance%20overnight%20and%20start%20it%20in%20the%20morning.%20Absence%20of%20the%20instance%2Dscheduling%20tag%20will%20have%20the%20same%20effect.)

* Updating go dependencies to the latest version
* Moving `strings.ToLower` into the function code since handler can't be tested while still allowing the action parameter to be case-insensitive.
* Amending the mock instance ids, using the last three digits to indicate expected action which makes it easier to troubleshoot.
* Adding a go_proxy to the Dockerfile to speed up the build step. The automatically selected proxy periodically timed out when fetching go libraries.
