### PR TITLE
🧪 Amend Testing Thresholds to Reduce Noise

### DIFF
--- a/instance-scheduler/main_int_test.go
+++ b/instance-scheduler/main_int_test.go
@@ -40,11 +40,11 @@ func TestHandler(t *testing.T) {
 			}
 		}
 		addMsg := "Please manually check the Instance Scheduler logs and verify this is reasonable. If it is reasonable, modify and adjust this test accordingly."
-		assert.Greater(t, res.ActedUpon, 20, fmt.Sprintf("Number of instances acted upon seems too low. %v", addMsg))
+		assert.Greater(t, res.ActedUpon, 0, fmt.Sprintf("Number of instances acted upon seems too low. %v", addMsg))
 		assert.Less(t, res.ActedUpon, 200, fmt.Sprintf("Number of instances acted upon seems too high. %v", addMsg))
 		assert.Greater(t, res.Skipped, 0, fmt.Sprintf("Number of skipped instances seems too low. %v", addMsg))
-		assert.Less(t, res.Skipped, 180, fmt.Sprintf("Number of skipped instances seems too high. %v", addMsg))
-		assert.Greater(t, res.SkippedAutoScaled, 20, fmt.Sprintf("Number of skipped instances that belong to an Auto Scaling group seems too low. %v", addMsg))
-		assert.Less(t, res.SkippedAutoScaled, 100, fmt.Sprintf("Number of skipped instances that belong to an Auto Scaling group seems too high. %v", addMsg))
+		assert.Less(t, res.Skipped, 200, fmt.Sprintf("Number of skipped instances seems too high. %v", addMsg))
+		assert.Greater(t, res.SkippedAutoScaled, 0, fmt.Sprintf("Number of skipped instances that belong to an Auto Scaling group seems too low. %v", addMsg))
+		assert.Less(t, res.SkippedAutoScaled, 200, fmt.Sprintf("Number of skipped instances that belong to an Auto Scaling group seems too high. %v", addMsg))
 	})
 }


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/modernisation-platform-instance-scheduler/issues/138
- To reduce alert noise caused by the static values

## ♻️ What's changed

- Amended the static values used in the integration tests that compare against the live environment to reduce the noise of these alerts. 

## 📝 Notes

- The alerts mainly cause noise and, in my experience, have not identified issues in the code before deployment - just slowed down the process
- We're keeping the alert for now but just amending the thresholds so they should only alert when something has really gone wrong or the environment has drastically changed
- Ideally, in the future, we can decouple the integration tests from using the live environment state to tests - but there are a few other areas we want to tackle first to build a bit more confidence in our quality checks such as improving unit tests and refactoring the code to make it easier to read
- Further details can be found in this [discussion](https://mojdt.slack.com/archives/C013RM6MFFW/p1712051311040569)