### PR TITLE
♻️ Refactor `InstanceSchedulingRequest.Action` parsing

### DIFF
--- a/instance-scheduler/ec2.go
+++ b/instance-scheduler/ec2.go
@@ -27,17 +27,9 @@ type IEC2InstancesAPI interface {
 }
 
 func stopStartTestInstancesInMemberAccount(client IEC2InstancesAPI, action string) *InstanceCount {
-	action = strings.ToLower(action)
 	count := &InstanceCount{actedUpon: 0, skipped: 0, skippedAutoScaled: 0}
-	switch action {
-	case "test", "start", "stop":
-		break
-	default:
-		log.Print("ERROR: Invalid Action. Must be one of 'start' 'stop' 'test'")
-		return count
-	}
-	result, err := client.DescribeInstances(context.TODO(), &ec2.DescribeInstancesInput{})
 
+	result, err := client.DescribeInstances(context.TODO(), &ec2.DescribeInstancesInput{})
 	if err != nil {
 		log.Println("ERROR: Could not retrieve information about Amazon EC2 instances in member account:", err)
 		return count

--- a/instance-scheduler/ec2_test.go
+++ b/instance-scheduler/ec2_test.go
@@ -140,7 +140,7 @@ func TestStopStartTestInstancesInMemberAccount(t *testing.T) {
 					},
 				},
 			},
-			action:        "Test",
+			action:        "test",
 			expectedCount: InstanceCount{4, 3, 2},
 		},
 		{
@@ -249,7 +249,7 @@ func TestStopStartTestInstancesInMemberAccount(t *testing.T) {
 					},
 				},
 			},
-			action:        "Stop",
+			action:        "stop",
 			expectedCount: InstanceCount{5, 2, 2},
 		},
 		{
@@ -358,96 +358,8 @@ func TestStopStartTestInstancesInMemberAccount(t *testing.T) {
 					},
 				},
 			},
-			action:        "Start",
-			expectedCount: InstanceCount{5, 2, 2},
-		},
-		{
-			testTitle: "testing if action input is not case sensitive when passing start",
-			client: &mockIEC2InstancesAPI{
-				DescribeInstancesOutput: &ec2.DescribeInstancesOutput{
-					Reservations: []ec2type.Reservation{
-						{
-							ReservationId: aws.String("r-0899f7abdd9be06d8"),
-							Instances: []ec2type.Instance{
-								// instance-scheduling = skip-auto-start, therefore skip auto start, skipped: 1
-								{
-									InstanceId: aws.String("i-9262279981"),
-									Tags: []ec2type.Tag{
-										{
-											Key:   aws.String("instance-scheduling"),
-											Value: aws.String("skip-auto-start"),
-										},
-									},
-								},
-								// instance-scheduling = skip-auto-stop, therefore skip auto stop, but not start, acted upon: 1
-								{
-									InstanceId: aws.String("i-1265579989"),
-									Tags: []ec2type.Tag{
-										{
-											Key:   aws.String("instance-scheduling"),
-											Value: aws.String("skip-auto-stop"),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
 			action:        "start",
-			expectedCount: InstanceCount{1, 1, 0},
-		},
-		{
-			// aws:autoscaling:groupName tag is set, but action is an empty string, therefore InstanceCount: {0,0,0}
-			testTitle: "testing empty action input",
-			client: &mockIEC2InstancesAPI{
-				DescribeInstancesOutput: &ec2.DescribeInstancesOutput{
-					Reservations: []ec2type.Reservation{
-						{
-							ReservationId: aws.String("r-0899f7abdd9be06d8"),
-							Instances: []ec2type.Instance{
-								{
-									InstanceId: aws.String("i-6567788909"),
-									Tags: []ec2type.Tag{
-										{
-											Key:   aws.String("aws:autoscaling:groupName"),
-											Value: aws.String("bastion-linux"),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			action:        "",
-			expectedCount: InstanceCount{0, 0, 0},
-		},
-		{
-			// instance-scheduling = default, but action value is invalid, therefore InstanceCount: {0,0,0}
-			testTitle: "testing invalid action input",
-			client: &mockIEC2InstancesAPI{
-				DescribeInstancesOutput: &ec2.DescribeInstancesOutput{
-					Reservations: []ec2type.Reservation{
-						{
-							ReservationId: aws.String("r-0899f7abdd9be06d8"),
-							Instances: []ec2type.Instance{
-								{
-									InstanceId: aws.String("i-1265579989"),
-									Tags: []ec2type.Tag{
-										{
-											Key:   aws.String("instance-scheduling"),
-											Value: aws.String("default"),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			action:        "invalid",
-			expectedCount: InstanceCount{0, 0, 0},
+			expectedCount: InstanceCount{5, 2, 2},
 		},
 	}
 

--- a/instance-scheduler/main.go
+++ b/instance-scheduler/main.go
@@ -32,7 +32,12 @@ type InstanceSchedulingResponse struct {
 
 func handler(request InstanceSchedulingRequest) (events.APIGatewayProxyResponse, error) {
 	log.Printf("BEGIN: Instance scheduling v%v\n", INSTANCE_SCHEDULER_VERSION)
-	log.Printf("Action=%v\n", request.Action)
+
+	action, err := parseAction(request.Action)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	skipAccounts := os.Getenv("INSTANCE_SCHEDULING_SKIP_ACCOUNTS")
 	log.Printf("INSTANCE_SCHEDULING_SKIP_ACCOUNTS=%v\n", skipAccounts)
 
@@ -72,12 +77,12 @@ func handler(request InstanceSchedulingRequest) (events.APIGatewayProxyResponse,
 		} else {
 			memberAccountNames = append(memberAccountNames, accName)
 			log.Printf("BEGIN: Instance scheduling for member account: accountName=%v, accountId=%v\n", accName, accId)
-			count := stopStartTestInstancesInMemberAccount(ec2Client, request.Action)
+			count := stopStartTestInstancesInMemberAccount(ec2Client, action)
 			totalCount.ActedUpon += count.actedUpon
 			totalCount.Skipped += count.skipped
 			totalCount.SkippedAutoScaled += count.skippedAutoScaled
 
-			rdsCount := StopStartTestRDSInstancesInMemberAccount(rdsClient, request.Action)
+			rdsCount := StopStartTestRDSInstancesInMemberAccount(rdsClient, action)
 			totalCount.RDSActedUpon += rdsCount.RDSActedUpon
 			totalCount.RDSSkipped += rdsCount.RDSSkipped
 

--- a/instance-scheduler/rds.go
+++ b/instance-scheduler/rds.go
@@ -27,16 +27,7 @@ func StopStartTestRDSInstancesInMemberAccount(rdsClient IRDSInstancesAPI, action
 	action = strings.ToLower(action)
 	rdscount := &RDSInstanceCount{RDSActedUpon: 0, RDSSkipped: 0}
 
-	switch action {
-	case "start", "stop", "test":
-		break
-	default:
-		log.Print("ERROR: Invalid Action. Must be one of 'start' 'stop' 'test'")
-		return rdscount
-	}
-
 	result, err := rdsClient.DescribeDBInstances(context.TODO(), &rds.DescribeDBInstancesInput{})
-
 	if err != nil {
 		log.Print("ERROR: Could not retrieve information about Amazon RDS instances in member account:\n", err)
 		return rdscount

--- a/instance-scheduler/rds_test.go
+++ b/instance-scheduler/rds_test.go
@@ -105,7 +105,7 @@ func TestStopStartTestRDSInstancesInMemberAccount(t *testing.T) {
 					},
 				},
 			},
-			action:        "Test",
+			action:        "test",
 			expectedCount: RDSInstanceCount{4, 3},
 		},
 		{
@@ -180,7 +180,7 @@ func TestStopStartTestRDSInstancesInMemberAccount(t *testing.T) {
 					},
 				},
 			},
-			action:        "Stop",
+			action:        "stop",
 			expectedCount: RDSInstanceCount{5, 2},
 		},
 		{
@@ -255,60 +255,8 @@ func TestStopStartTestRDSInstancesInMemberAccount(t *testing.T) {
 					},
 				},
 			},
-			action:        "Start",
+			action:        "start",
 			expectedCount: RDSInstanceCount{5, 2},
-		},
-		{
-			testTitle: "RDS testing if action input is not case sensitive when passing start",
-			client: &mockIRDSInstancesAPI{
-				DescribeDBInstancesOutput: &rds.DescribeDBInstancesOutput{
-					DBInstances: []rdstype.DBInstance{
-						// RDS instance-scheduling = skip-auto-start, therefore skip auto start, skipped: 1
-						{
-							DBInstanceIdentifier: aws.String("test-database"),
-							TagList: []rdstype.Tag{
-								{
-									Key:   aws.String("instance-scheduling"),
-									Value: aws.String("skip-auto-start"),
-								},
-							},
-						},
-						// instance-scheduling = skip-auto-stop, therefore skip auto stop, but not start, acted upon: 1
-						{
-							DBInstanceIdentifier: aws.String("test-database-2"),
-							TagList: []rdstype.Tag{
-								{
-									Key:   aws.String("instance-scheduling"),
-									Value: aws.String("skip-auto-stop"),
-								},
-							},
-						},
-					},
-				},
-			},
-			action:        "sTARt",
-			expectedCount: RDSInstanceCount{1, 1},
-		},
-		{
-			// RDS instance-scheduling = default, but action value is invalid, therefore RDSInstanceCount: {0,0}
-			testTitle: "RDS testing invalid action input",
-			client: &mockIRDSInstancesAPI{
-				DescribeDBInstancesOutput: &rds.DescribeDBInstancesOutput{
-					DBInstances: []rdstype.DBInstance{
-						{
-							DBInstanceIdentifier: aws.String("test-database"),
-							TagList: []rdstype.Tag{
-								{
-									Key:   aws.String("instance-scheduling"),
-									Value: aws.String("default"),
-								},
-							},
-						},
-					},
-				},
-			},
-			action:        "invalid",
-			expectedCount: RDSInstanceCount{0, 0},
 		},
 	}
 

--- a/instance-scheduler/utils.go
+++ b/instance-scheduler/utils.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log"
 	"strings"
 
@@ -59,4 +60,15 @@ func getNonProductionAccounts(environments string, skipAccountNames string) map[
 		}
 	}
 	return accounts
+}
+
+func parseAction(action string) (string, error) {
+	log.Printf("Action=%v\n", action)
+	actionAsLower := strings.ToLower(action)
+
+	switch actionAsLower {
+	case "test", "start", "stop":
+		return actionAsLower, nil
+	}
+	return "", errors.New("ERROR: Invalid Action. Must be one of 'start' 'stop' 'test'")
 }

--- a/instance-scheduler/utils_test.go
+++ b/instance-scheduler/utils_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/stretchr/testify/assert"
 )
 
 type mockGetParameter func(ctx context.Context, params *ssm.GetParameterInput, optFns ...func(*ssm.Options)) (*ssm.GetParameterOutput, error)
@@ -162,6 +163,52 @@ func TestGetNonProductionAccounts(t *testing.T) {
 			got := getNonProductionAccounts(subtest.environments, subtest.skipAccounts)
 			if !reflect.DeepEqual(subtest.want, got) {
 				t.Errorf("want %v, got %v", subtest.want, got)
+			}
+		})
+	}
+}
+
+func TestParseAction(t *testing.T) {
+	tests := []struct {
+		title       string
+		action      string
+		want        string
+		expectError bool
+	}{
+		{
+			title:       "returns 'test' for `TEST`",
+			action:      "TEST",
+			want:        "test",
+			expectError: false,
+		},
+		{
+			title:       "returns 'start' for `START`",
+			action:      "START",
+			want:        "start",
+			expectError: false,
+		},
+		{
+			title:       "returns 'stop' for `STOP`",
+			action:      "STOP",
+			want:        "stop",
+			expectError: false,
+		},
+		{
+			title:       "returns empty string and error for invalid action`",
+			action:      "Invalid action name! 😱",
+			want:        "",
+			expectError: true,
+		},
+	}
+
+	for _, subtest := range tests {
+		t.Run(subtest.title, func(t *testing.T) {
+			got, err := parseAction(subtest.action)
+			assert.Equal(t, subtest.want, got)
+			if subtest.expectError {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/modernisation-platform/issues/6687
- Remove some duplication of parsing/validating the Action value

## ♻️ What's changed

- ♻️ Refactored all logic related to parsing the Action value to the beginning of the script (failing fast) - and ensuring downstream functions use a parsed value instead of the raw value

## 📝 Notes

- 🙈 I've not added unit tests to the main handler in this PR for this specific scenario, requires a bit more work to get the main handler unit testable 🧪