### PR TITLE
✨ Add Unit Test For Invalid Action

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -4,23 +4,22 @@ on:
     branches:
       - main
     paths:
-      - 'instance-scheduler/**'
-      - '.github/workflows/build-test-push.yml'
-      - '**.yaml'
-      - '**.yml'
-      - '**.json'
-      - 'Makefile'
+      - "instance-scheduler/**"
+      - ".github/workflows/build-test-push.yml"
+      - "**.yaml"
+      - "**.yml"
+      - "**.json"
+      - "Makefile"
   pull_request:
     branches:
       - main
-    types: [ opened, edited, reopened, synchronize ]
     paths:
-      - 'instance-scheduler/**'
-      - '.github/workflows/build-test-push.yml'
-      - '**.yaml'
-      - '**.yml'
-      - '**.json'
-      - 'Makefile'
+      - "instance-scheduler/**"
+      - ".github/workflows/build-test-push.yml"
+      - "**.yaml"
+      - "**.yml"
+      - "**.json"
+      - "Makefile"
   workflow_dispatch:
 env:
   AWS_REGION: "eu-west-2"
@@ -45,7 +44,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: '>=1.18'
+          go-version: ">=1.18"
       - uses: aws-actions/setup-sam@342dcc4899c07fedf41f91cbb1e6c68925a85d37 # v2
       - name: SAM Validate
         run: |

--- a/instance-scheduler/main.go
+++ b/instance-scheduler/main.go
@@ -33,9 +33,24 @@ type InstanceSchedulingResponse struct {
 func handler(request InstanceSchedulingRequest) (events.APIGatewayProxyResponse, error) {
 	log.Printf("BEGIN: Instance scheduling v%v\n", INSTANCE_SCHEDULER_VERSION)
 
+	instanceSchedulingResponse := &InstanceSchedulingResponse{
+		Action:                request.Action,
+		MemberAccountNames:    []string{},
+		NonMemberAccountNames: []string{},
+		ActedUpon:             0,
+		Skipped:               0,
+		SkippedAutoScaled:     0,
+		RDSActedUpon:          0,
+		RDSSkipped:            0,
+	}
+
 	action, err := parseAction(request.Action)
 	if err != nil {
-		log.Fatal(err)
+		body, _ := json.Marshal(instanceSchedulingResponse)
+		return events.APIGatewayProxyResponse{
+			Body:       string(body),
+			StatusCode: 400,
+		}, err
 	}
 
 	skipAccounts := os.Getenv("INSTANCE_SCHEDULING_SKIP_ACCOUNTS")
@@ -58,16 +73,6 @@ func handler(request InstanceSchedulingRequest) (events.APIGatewayProxyResponse,
 	accounts := getNonProductionAccounts(environments, skipAccounts)
 	memberAccountNames := []string{}
 	nonMemberAccountNames := []string{}
-	totalCount := &InstanceSchedulingResponse{
-		Action:                request.Action,
-		MemberAccountNames:    []string{},
-		NonMemberAccountNames: []string{},
-		ActedUpon:             0,
-		Skipped:               0,
-		SkippedAutoScaled:     0,
-		RDSActedUpon:          0,
-		RDSSkipped:            0,
-	}
 	for accName, accId := range accounts {
 		ec2Client := getEc2ClientForMemberAccount(cfg, accName, accId)
 		rdsClient := getRDSClientForMemberAccount(cfg, accName, accId)
@@ -78,13 +83,13 @@ func handler(request InstanceSchedulingRequest) (events.APIGatewayProxyResponse,
 			memberAccountNames = append(memberAccountNames, accName)
 			log.Printf("BEGIN: Instance scheduling for member account: accountName=%v, accountId=%v\n", accName, accId)
 			count := stopStartTestInstancesInMemberAccount(ec2Client, action)
-			totalCount.ActedUpon += count.actedUpon
-			totalCount.Skipped += count.skipped
-			totalCount.SkippedAutoScaled += count.skippedAutoScaled
+			instanceSchedulingResponse.ActedUpon += count.actedUpon
+			instanceSchedulingResponse.Skipped += count.skipped
+			instanceSchedulingResponse.SkippedAutoScaled += count.skippedAutoScaled
 
 			rdsCount := StopStartTestRDSInstancesInMemberAccount(rdsClient, action)
-			totalCount.RDSActedUpon += rdsCount.RDSActedUpon
-			totalCount.RDSSkipped += rdsCount.RDSSkipped
+			instanceSchedulingResponse.RDSActedUpon += rdsCount.RDSActedUpon
+			instanceSchedulingResponse.RDSSkipped += rdsCount.RDSSkipped
 
 			log.Printf("END: Instance scheduling for member account: accountName=%v, accountId=%v\n", accName, accId)
 		}
@@ -99,19 +104,9 @@ func handler(request InstanceSchedulingRequest) (events.APIGatewayProxyResponse,
 		log.Printf("Ignored %v non-member accounts lacking InstanceSchedulerAccess role: %v\n", len(nonMemberAccountNames), nonMemberAccountNames)
 	}
 
-	body := &InstanceSchedulingResponse{
-		Action:                request.Action,
-		MemberAccountNames:    memberAccountNames,
-		NonMemberAccountNames: nonMemberAccountNames,
-		ActedUpon:             totalCount.ActedUpon,
-		Skipped:               totalCount.Skipped,
-		SkippedAutoScaled:     totalCount.SkippedAutoScaled,
-		RDSActedUpon:          totalCount.RDSActedUpon,
-		RDSSkipped:            totalCount.RDSSkipped,
-	}
-	bodyJson, _ := json.Marshal(body)
+	body, _ := json.Marshal(instanceSchedulingResponse)
 	return events.APIGatewayProxyResponse{
-		Body:       string(bodyJson),
+		Body:       string(body),
 		StatusCode: 200,
 	}, nil
 }

--- a/instance-scheduler/main_test.go
+++ b/instance-scheduler/main_test.go
@@ -1,1 +1,15 @@
 package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandlerUnit(t *testing.T) {
+	t.Run("returns 400 error when `InstanceSchedulingRequest.Action` is invalid", func(t *testing.T) {
+		response, err := handler(InstanceSchedulingRequest{Action: "Invalid Action! 😱"})
+		assert.Equal(t, response.StatusCode, 400)
+		assert.NotNil(t, err)
+	})
+}


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/modernisation-platform/issues/6687
- To increase test coverage by unit testing code inside the the `handler` function

## ♻️ What's changed

- ♻️ Refactored error logic to return an error over using `log.Fatal()` - this should not impact the success/failure status of the lambda since returning a status code of `400` will be considered a failure. This should also increase the verbosity of the error as receiving a `400` will indicate an issue with the request over the generic `500` error.
- ♻️ Refactored the creation of the `Response` Object to the top of the script -  also removed the duplicated creation of this object 🥳
- ✨ Added unit test for `handler` function 
- 🔥 Removed trigger for build-test-push action when PR metadata changes (title, description etc.) - the integration tests take a fair chunk of time, so running them every time I make a spelling mistake in the description is a bit excessive! 🙈🤭 

## 📝 Notes

- 🤔 I'm not entirely sure if we make use of the response? But using it over `log.Fatal()` makes the code easier to test at least 🧪