### PR TITLE
🫧 Bubble Process Logic Upwards For EC2 Instances

### DIFF
--- a/instance-scheduler/ec2.go
+++ b/instance-scheduler/ec2.go
@@ -66,45 +66,46 @@ func stopStartTestInstancesInMemberAccount(client IEC2InstancesAPI, action strin
 			if instanceIsPartOfAutoScalingGroup {
 				log.Print(skippedAutoScaledMessage)
 				skippedAutoScaledInstances = append(skippedAutoScaledInstances, *i.InstanceId)
-			} else if instanceSchedulingTag == "skip-scheduling" {
+				continue
+			}
+			if instanceSchedulingTag == "skip-scheduling" {
 				log.Print(skippedMessage)
 				skippedInstances = append(skippedInstances, *i.InstanceId)
-			} else if instanceSchedulingTag == "skip-auto-stop" {
-				if action == "stop" {
-					log.Print(skippedMessage)
-					skippedInstances = append(skippedInstances, *i.InstanceId)
-				} else if action == "start" {
-					log.Print(actedUponMessage)
-					instancesActedUpon = append(instancesActedUpon, *i.InstanceId)
-					startInstance(client, *i.InstanceId)
-				} else if action == "test" {
-					log.Printf("Successfully tested skipping instance with Id %v\n", *i.InstanceId)
-					skippedInstances = append(skippedInstances, *i.InstanceId)
-				}
-			} else if instanceSchedulingTag == "skip-auto-start" {
-				if action == "stop" {
-					log.Print(actedUponMessage)
-					instancesActedUpon = append(instancesActedUpon, *i.InstanceId)
-					stopInstance(client, *i.InstanceId)
-				} else if action == "start" {
-					log.Print(skippedMessage)
-					skippedInstances = append(skippedInstances, *i.InstanceId)
-				} else if action == "test" {
-					log.Printf("Successfully tested skipping instance with Id %v\n", *i.InstanceId)
-					skippedInstances = append(skippedInstances, *i.InstanceId)
-				}
-			} else { // if instance-scheduling tag is missing, or the value of the tag either default, not valid or empty the instance will be actioned
-				log.Print(actedUponMessage)
-				instancesActedUpon = append(instancesActedUpon, *i.InstanceId)
-				if action == "stop" {
-					stopInstance(client, *i.InstanceId)
-				} else if action == "start" {
-					startInstance(client, *i.InstanceId)
-				} else if action == "test" {
-					log.Printf("Successfully tested instance with Id %v\n", *i.InstanceId)
-				}
+				continue
 			}
 
+			if action == "test" {
+				if instanceSchedulingTag == "skip-auto-stop" || instanceSchedulingTag == "skip-auto-start" {
+					log.Print(skippedMessage)
+					skippedInstances = append(skippedInstances, *i.InstanceId)
+					continue
+				}
+				instancesActedUpon = append(instancesActedUpon, *i.InstanceId)
+				log.Printf("Successfully tested instance with Id %v\n", *i.InstanceId)
+				continue
+			}
+			if action == "stop" {
+				if instanceSchedulingTag == "skip-auto-stop" {
+					log.Print(skippedMessage)
+					skippedInstances = append(skippedInstances, *i.InstanceId)
+					continue
+				}
+				instancesActedUpon = append(instancesActedUpon, *i.InstanceId)
+				stopInstance(client, *i.InstanceId)
+				log.Print(actedUponMessage)
+				continue
+			}
+			if action == "start" {
+				if instanceSchedulingTag == "skip-auto-start" {
+					log.Print(skippedMessage)
+					skippedInstances = append(skippedInstances, *i.InstanceId)
+					continue
+				}
+				instancesActedUpon = append(instancesActedUpon, *i.InstanceId)
+				startInstance(client, *i.InstanceId)
+				log.Print(actedUponMessage)
+				continue
+			}
 		}
 	}
 


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/modernisation-platform/issues/6687
- To decouple the responsibilities of the three separate processes: "start", "stop" and "test"

## ♻️ What's changed

- Refactored all logic related to starting EC2 instances into the `startEc2Instances` function
- Refactored all logic related to stopping EC2 instances into the `stopEc2Instances` function
- Refactored all logic related to testing EC2 instances into the `testEc2Instances` function

## 📝 Notes

- The code currently is highly coupled at a technical level - this PR takes a step towards decoupling which better highlights the three current supported processes and allows the specific business logic of each process to shine through
- The changes implemented are non-functional, so won't affect how the current function operates - the changes just shift the logic around for readability (highlighted by the fact that no tests were needed to be changed for this PR ✅)