### PR TITLE
✨ Add Explicit 500 Error Response When Config Cannot Load

### DIFF
--- a/instance-scheduler/main_int_test.go
+++ b/instance-scheduler/main_int_test.go
@@ -16,7 +16,8 @@ func TestHandler(t *testing.T) {
 		// lacking the InstanceSchedulerAccess role, but they have the '-development' suffix typically present in member accounts.
 		os.Setenv("INSTANCE_SCHEDULING_SKIP_ACCOUNTS", "mi-platform-development,analytical-platform-data-development,analytical-platform-development,moj-network-operations-centre-preproduction,opg-lpa-data-store-development,")
 
-		result, err := handler(InstanceSchedulingRequest{Action: "Test"})
+		instanceScheduler := InstanceScheduler{loadDefaultConfig: LoadDefaultConfig}
+		result, err := instanceScheduler.handler(InstanceSchedulingRequest{Action: "Test"})
 		if err != nil {
 			t.Fatalf("Failed to run lambda's handler: %v", err)
 		}

--- a/instance-scheduler/main_test.go
+++ b/instance-scheduler/main_test.go
@@ -1,15 +1,29 @@
 package main
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
 )
 
+func mockLoadDefaultConfig() (aws.Config, error) {
+	return *aws.NewConfig(), errors.New("Mock Error!")
+}
+
 func TestHandlerUnit(t *testing.T) {
 	t.Run("returns 400 error when `InstanceSchedulingRequest.Action` is invalid", func(t *testing.T) {
-		response, err := handler(InstanceSchedulingRequest{Action: "Invalid Action! 😱"})
+		instanceScheduler := InstanceScheduler{loadDefaultConfig: mockLoadDefaultConfig}
+		response, err := instanceScheduler.handler(InstanceSchedulingRequest{Action: "Invalid Action! 😱"})
 		assert.Equal(t, response.StatusCode, 400)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("returns 500 error when default config cannot load", func(t *testing.T) {
+		instanceScheduler := InstanceScheduler{loadDefaultConfig: mockLoadDefaultConfig}
+		response, err := instanceScheduler.handler(InstanceSchedulingRequest{Action: "test"})
+		assert.Equal(t, response.StatusCode, 500)
 		assert.NotNil(t, err)
 	})
 }

--- a/instance-scheduler/utils.go
+++ b/instance-scheduler/utils.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 )
@@ -71,4 +72,8 @@ func parseAction(action string) (string, error) {
 		return actionAsLower, nil
 	}
 	return "", errors.New("ERROR: Invalid Action. Must be one of 'start' 'stop' 'test'")
+}
+
+func LoadDefaultConfig() (aws.Config, error) {
+	return config.LoadDefaultConfig(context.TODO(), config.WithRegion("eu-west-2"))
 }


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/modernisation-platform/issues/6687
- To add explicit response error when default config fails to load 

## ♻️ What's changed

- Added explicit response error when default config fails to load 

## 📝 Notes

- Mainly this change required the setup of enabling Dependency Injection into the handler since the config is loaded from the machine it runs on (which we want to avoid in unit testing 🧪). So this PR mainly sets up that framework of enabling dependencies to be injected to increase unit test coverage of the main file 🥳