### PR TITLE
Bubble Process Logic Upwards For RDS Instances

### DIFF
--- a/instance-scheduler/ec2.go
+++ b/instance-scheduler/ec2.go
@@ -48,7 +48,7 @@ func parseInstanceTags(instance ec2type.Instance, skippedInstances []string, ski
 	isSkipSchedulingTag := false
 	for _, tag := range instance.Tags {
 		if *tag.Key == "aws:autoscaling:groupName" {
-			log.Printf("Skip instance because aws:autoscaling:groupName tag because it is part of an Auto Scaling group\n")
+			log.Printf("INFO: Skip instance because aws:autoscaling:groupName tag because it is part of an Auto Scaling group\n")
 			skippedAutoScaledInstances = append(skippedAutoScaledInstances, *instance.InstanceId)
 			isPartOfAutoScalingGroup = true
 		}
@@ -56,7 +56,7 @@ func parseInstanceTags(instance ec2type.Instance, skippedInstances []string, ski
 			instanceSchedulingTag = *tag.Value
 		}
 		if *tag.Key == "instance-scheduling" && *tag.Value == "skip-scheduling" {
-			log.Printf("Skip instance because instance-scheduling tag having value 'skip-scheduling'\n")
+			log.Printf("INFO: Skip instance because instance-scheduling tag having value 'skip-scheduling'\n")
 			skippedInstances = append(skippedInstances, *instance.InstanceId)
 			isSkipSchedulingTag = true
 		}

--- a/instance-scheduler/rds.go
+++ b/instance-scheduler/rds.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
+	rdstype "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
@@ -23,96 +24,139 @@ type IRDSInstancesAPI interface {
 	DescribeDBInstances(ctx context.Context, params *rds.DescribeDBInstancesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error)
 }
 
-func StopStartTestRDSInstancesInMemberAccount(rdsClient IRDSInstancesAPI, action string) *RDSInstanceCount {
+func StopStartTestRDSInstancesInMemberAccount(RDSClient IRDSInstancesAPI, action string) *RDSInstanceCount {
 	action = strings.ToLower(action)
-	rdscount := &RDSInstanceCount{RDSActedUpon: 0, RDSSkipped: 0}
 
-	result, err := rdsClient.DescribeDBInstances(context.TODO(), &rds.DescribeDBInstancesInput{})
-	if err != nil {
-		log.Print("ERROR: Could not retrieve information about Amazon RDS instances in member account:\n", err)
-		return rdscount
-	}
-
-	RDSinstancesActedUpon := []string{}
-	RDSskippedInstances := []string{}
-
-	for _, rdsInstance := range result.DBInstances {
-		var instanceSchedulingTag string
-		for _, tag := range rdsInstance.TagList {
-			if *tag.Key == "instance-scheduling" {
-				instanceSchedulingTag = *tag.Value
-				break
-			}
-		}
-
-		instanceSchedulingTagDescr := fmt.Sprintf("with instance-scheduling tag having value '%v'", instanceSchedulingTag)
-		if instanceSchedulingTag == "" {
-			instanceSchedulingTagDescr = "with instance-scheduling tag being absent"
-		}
-
-		actedUponMessage := fmt.Sprintf("%v instance %v %v\n", action, *rdsInstance.DBInstanceIdentifier, instanceSchedulingTagDescr)
-		skippedMessage := fmt.Sprintf("Skipped instance %v %v\n", *rdsInstance.DBInstanceIdentifier, instanceSchedulingTagDescr)
-
-		// Tag key: instance-scheduling
-		// Valid values: default (same as absence of tag), skip-scheduling, skip-auto-stop, skip-auto-start
-
-		if instanceSchedulingTag == "skip-scheduling" {
-			RDSskippedInstances = append(RDSskippedInstances, *rdsInstance.DBInstanceIdentifier)
-			log.Print(skippedMessage)
-			continue
-		}
-		if action == "stop" {
-			if instanceSchedulingTag == "skip-auto-stop" {
-				RDSskippedInstances = append(RDSskippedInstances, *rdsInstance.DBInstanceIdentifier)
-				log.Print(skippedMessage)
-				continue
-			}
-			RDSinstancesActedUpon = append(RDSinstancesActedUpon, *rdsInstance.DBInstanceIdentifier)
-			stopRDSInstance(rdsClient, *rdsInstance.DBInstanceIdentifier)
-			log.Print(actedUponMessage)
-			continue
-		}
-		if action == "start" {
-			if instanceSchedulingTag == "skip-auto-start" {
-				RDSskippedInstances = append(RDSskippedInstances, *rdsInstance.DBInstanceIdentifier)
-				log.Print(skippedMessage)
-				continue
-			}
-			RDSinstancesActedUpon = append(RDSinstancesActedUpon, *rdsInstance.DBInstanceIdentifier)
-			startRDSInstance(rdsClient, *rdsInstance.DBInstanceIdentifier)
-			log.Print(actedUponMessage)
-			continue
-		}
-		if action == "test" {
-			if instanceSchedulingTag == "skip-auto-stop" || instanceSchedulingTag == "skip-auto-start" {
-				RDSskippedInstances = append(RDSskippedInstances, *rdsInstance.DBInstanceIdentifier)
-				log.Printf("Successfully tested skipping instance with Id %v\n", *rdsInstance.DBInstanceIdentifier)
-				continue
-			}
-			RDSinstancesActedUpon = append(RDSinstancesActedUpon, *rdsInstance.DBInstanceIdentifier)
-			log.Print(actedUponMessage)
-			continue
-		}
-	}
-
-	acted := "Started"
 	if action == "stop" {
-		acted = "Stopped"
-	} else if action == "test" {
-		acted = "Tested"
-	}
-	if len(RDSinstancesActedUpon) > 0 {
-		log.Printf("%v %v RDS instances: %v\n", acted, len(RDSinstancesActedUpon), RDSinstancesActedUpon)
-		rdscount.RDSActedUpon = len(RDSinstancesActedUpon)
-	} else {
-		log.Printf("WARN: No RDS instances found to %v!\n", action)
-	}
-	if len(RDSskippedInstances) > 0 {
-		log.Printf("Skipped %v RDS instances due to instance-scheduling tag: %v\n", len(RDSskippedInstances), RDSskippedInstances)
-		rdscount.RDSSkipped = len(RDSskippedInstances)
+		result, err := RDSClient.DescribeDBInstances(context.TODO(), &rds.DescribeDBInstancesInput{})
+		if err != nil {
+			log.Print("ERROR: Could not retrieve information about Amazon RDS instances in member account:\n", err)
+			return &RDSInstanceCount{RDSActedUpon: 0, RDSSkipped: 0}
+		}
+
+		instancesActedUpon := []string{}
+		skippedInstances := []string{}
+
+		for _, RDSInstance := range result.DBInstances {
+			log.Printf("INFO: RDS Instance Identifier: [ %v ]\n", *RDSInstance.DBInstanceIdentifier)
+			instanceSchedulingTag, skipInstance, skippedInstancesModified := parseRDSInstanceTags(RDSInstance, skippedInstances)
+			skippedInstances = skippedInstancesModified
+
+			if skipInstance {
+				continue
+			}
+
+			if instanceSchedulingTag == "skip-auto-stop" {
+				skippedInstances = append(skippedInstances, *RDSInstance.DBInstanceIdentifier)
+				log.Printf("INFO: Skipped RDS instance because instance-scheduling tag having value 'skip-auto-stop'\n")
+				continue
+			}
+
+			instancesActedUpon = append(instancesActedUpon, *RDSInstance.DBInstanceIdentifier)
+			stopRDSInstance(RDSClient, *RDSInstance.DBInstanceIdentifier)
+			log.Printf("INFO: Stopped RDS instance because instance-scheduling tag is absent\n")
+			continue
+		}
+
+		log.Printf("INFO: Stopped %v instances: %v\n", len(instancesActedUpon), instancesActedUpon)
+		log.Printf("INFO: Skipped %v instances due to instance-scheduling tag: %v\n", len(skippedInstances), skippedInstances)
+
+		return &RDSInstanceCount{RDSActedUpon: len(instancesActedUpon), RDSSkipped: len(skippedInstances)}
 	}
 
-	return rdscount
+	if action == "start" {
+		result, err := RDSClient.DescribeDBInstances(context.TODO(), &rds.DescribeDBInstancesInput{})
+		if err != nil {
+			log.Print("ERROR: Could not retrieve information about Amazon RDS instances in member account:\n", err)
+			return &RDSInstanceCount{RDSActedUpon: 0, RDSSkipped: 0}
+		}
+
+		instancesActedUpon := []string{}
+		skippedInstances := []string{}
+
+		for _, RDSInstance := range result.DBInstances {
+			log.Printf("INFO: RDS Instance Identifier: [ %v ]\n", *RDSInstance.DBInstanceIdentifier)
+			instanceSchedulingTag, skipInstance, skippedInstancesModified := parseRDSInstanceTags(RDSInstance, skippedInstances)
+			skippedInstances = skippedInstancesModified
+
+			if skipInstance {
+				continue
+			}
+
+			if instanceSchedulingTag == "skip-auto-start" {
+				skippedInstances = append(skippedInstances, *RDSInstance.DBInstanceIdentifier)
+				log.Printf("INFO: Skipped RDS instance because instance-scheduling tag having value 'skip-auto-start'\n")
+				continue
+			}
+
+			instancesActedUpon = append(instancesActedUpon, *RDSInstance.DBInstanceIdentifier)
+			startRDSInstance(RDSClient, *RDSInstance.DBInstanceIdentifier)
+			log.Printf("INFO: Started RDS instance because instance-scheduling tag is absent\n")
+			continue
+		}
+
+		log.Printf("INFO: Started %v RDS instances: %v\n", len(instancesActedUpon), instancesActedUpon)
+		log.Printf("INFO: Skipped %v RDS instances due to instance-scheduling tag: %v\n", len(skippedInstances), skippedInstances)
+
+		return &RDSInstanceCount{RDSActedUpon: len(instancesActedUpon), RDSSkipped: len(skippedInstances)}
+
+	}
+
+	if action == "test" {
+		result, err := RDSClient.DescribeDBInstances(context.TODO(), &rds.DescribeDBInstancesInput{})
+		if err != nil {
+			log.Print("ERROR: Could not retrieve information about Amazon RDS instances in member account:\n", err)
+			return &RDSInstanceCount{RDSActedUpon: 0, RDSSkipped: 0}
+		}
+
+		instancesActedUpon := []string{}
+		skippedInstances := []string{}
+
+		for _, RDSInstance := range result.DBInstances {
+			log.Printf("INFO: RDS Instance Identifier: [ %v ]\n", *RDSInstance.DBInstanceIdentifier)
+			instanceSchedulingTag, skipInstance, skippedInstancesModified := parseRDSInstanceTags(RDSInstance, skippedInstances)
+			skippedInstances = skippedInstancesModified
+
+			if skipInstance {
+				continue
+			}
+
+			if instanceSchedulingTag == "skip-auto-stop" || instanceSchedulingTag == "skip-auto-start" {
+				skippedInstances = append(skippedInstances, *RDSInstance.DBInstanceIdentifier)
+				log.Printf("INFO: Skipped RDS instance with DB instance identifier %v because instance-scheduling tag having value 'skip-auto-stop' or 'skip-auto-start'", *RDSInstance.DBInstanceIdentifier)
+				continue
+			}
+
+			instancesActedUpon = append(instancesActedUpon, *RDSInstance.DBInstanceIdentifier)
+			log.Printf("INFO: Successfully tested RDS instance with DB instance identifier %v because instance-scheduling tag is absent\n")
+			continue
+		}
+
+		log.Printf("INFO: Started %v RDS instances: %v\n", len(instancesActedUpon), instancesActedUpon)
+		log.Printf("INFO: Skipped %v RDS instances due to instance-scheduling tag: %v\n", len(skippedInstances), skippedInstances)
+
+		return &RDSInstanceCount{RDSActedUpon: len(instancesActedUpon), RDSSkipped: len(skippedInstances)}
+	}
+
+	log.Fatalf("Invalid action: [ %v ]", action)
+	return nil
+}
+
+func parseRDSInstanceTags(instance rdstype.DBInstance, RDSskippedInstances []string) (string, bool, []string) {
+	var instanceSchedulingTag string
+	isSkipSchedulingTag := false
+	for _, tag := range instance.TagList {
+		if *tag.Key == "instance-scheduling" {
+			instanceSchedulingTag = *tag.Value
+		}
+		if *tag.Key == "instance-scheduling" && *tag.Value == "skip-scheduling" {
+			log.Printf("Skip instance because instance-scheduling tag having value 'skip-scheduling'\n")
+			RDSskippedInstances = append(RDSskippedInstances, *instance.DBInstanceIdentifier)
+			isSkipSchedulingTag = true
+		}
+	}
+
+	return instanceSchedulingTag, isSkipSchedulingTag, RDSskippedInstances
 }
 
 func startRDSInstance(client IRDSInstancesAPI, dbInstanceIdentifier string) {

--- a/instance-scheduler/rds.go
+++ b/instance-scheduler/rds.go
@@ -26,15 +26,15 @@ type IRDSInstancesAPI interface {
 
 func StopStartTestRDSInstancesInMemberAccount(RDSClient IRDSInstancesAPI, action string) *RDSInstanceCount {
 	if action == "stop" {
-		stopRDSInstances(RDSClient)
+		return stopRDSInstances(RDSClient)
 	}
 
 	if action == "start" {
-		startRDSInstances(RDSClient)
+		return startRDSInstances(RDSClient)
 	}
 
 	if action == "test" {
-		testRDSInstances(RDSClient)
+		return testRDSInstances(RDSClient)
 	}
 
 	log.Fatalf("Invalid action: [ %v ]", action)
@@ -65,7 +65,7 @@ func startRDSInstance(client IRDSInstancesAPI, dbInstanceIdentifier string) {
 
 	_, err := client.StartDBInstance(context.TODO(), input)
 	if err == nil {
-		log.Printf("Successfully started RDS instance with Identifier %v\n", dbInstanceIdentifier)
+		log.Printf("INFO: Successfully started RDS instance with Identifier %v\n", dbInstanceIdentifier)
 	} else {
 		log.Printf("ERROR: Could not start RDS instance: %v\n", err)
 	}
@@ -78,7 +78,7 @@ func stopRDSInstance(client IRDSInstancesAPI, dbInstanceIdentifier string) {
 
 	_, err := client.StopDBInstance(context.TODO(), input)
 	if err == nil {
-		log.Printf("Successfully stopped RDS instance with Identifier %v\n", dbInstanceIdentifier)
+		log.Printf("INFO: Successfully stopped RDS instance with Identifier %v\n", dbInstanceIdentifier)
 	} else {
 		log.Printf("ERROR: Could not stop RDS instance: %v\n", err)
 	}

--- a/instance-scheduler/rds.go
+++ b/instance-scheduler/rds.go
@@ -57,44 +57,41 @@ func StopStartTestRDSInstancesInMemberAccount(rdsClient IRDSInstancesAPI, action
 		// Valid values: default (same as absence of tag), skip-scheduling, skip-auto-stop, skip-auto-start
 
 		if instanceSchedulingTag == "skip-scheduling" {
-			log.Print(skippedMessage)
 			RDSskippedInstances = append(RDSskippedInstances, *rdsInstance.DBInstanceIdentifier)
-		} else if instanceSchedulingTag == "skip-auto-stop" {
-			if action == "stop" {
+			log.Print(skippedMessage)
+			continue
+		}
+		if action == "stop" {
+			if instanceSchedulingTag == "skip-auto-stop" {
+				RDSskippedInstances = append(RDSskippedInstances, *rdsInstance.DBInstanceIdentifier)
 				log.Print(skippedMessage)
-				RDSskippedInstances = append(RDSskippedInstances, *rdsInstance.DBInstanceIdentifier)
-			} else if action == "start" {
-				log.Print(actedUponMessage)
-				RDSinstancesActedUpon = append(RDSinstancesActedUpon, *rdsInstance.DBInstanceIdentifier)
-				startRDSInstance(rdsClient, *rdsInstance.DBInstanceIdentifier)
-			} else if action == "test" {
-				log.Printf("Successfully tested skipping instance with Id %v\n", *rdsInstance.DBInstanceIdentifier)
-				RDSskippedInstances = append(RDSskippedInstances, *rdsInstance.DBInstanceIdentifier)
+				continue
 			}
-		} else if instanceSchedulingTag == "skip-auto-start" {
-			if action == "stop" {
-				log.Print(actedUponMessage)
-				RDSinstancesActedUpon = append(RDSinstancesActedUpon, *rdsInstance.DBInstanceIdentifier)
-				stopRDSInstance(rdsClient, *rdsInstance.DBInstanceIdentifier)
-			} else if action == "start" {
-				log.Print(skippedMessage)
-				RDSskippedInstances = append(RDSskippedInstances, *rdsInstance.DBInstanceIdentifier)
-			} else if action == "test" {
-				log.Printf("Successfully tested skipping instance with Id %v\n", *rdsInstance.DBInstanceIdentifier)
-				RDSskippedInstances = append(RDSskippedInstances, *rdsInstance.DBInstanceIdentifier)
-			}
-
-		} else { // if instance-scheduling tag is missing, or the value of the tag either default, not valid or empty the RDS instance will be actioned
-			log.Print(actedUponMessage)
 			RDSinstancesActedUpon = append(RDSinstancesActedUpon, *rdsInstance.DBInstanceIdentifier)
-
-			if action == "stop" {
-				stopRDSInstance(rdsClient, *rdsInstance.DBInstanceIdentifier)
-			} else if action == "start" {
-				startRDSInstance(rdsClient, *rdsInstance.DBInstanceIdentifier)
-			} else if action == "test" {
-				log.Printf("Successfully tested RDS instance with Id %v\n", *rdsInstance.DBInstanceIdentifier)
+			stopRDSInstance(rdsClient, *rdsInstance.DBInstanceIdentifier)
+			log.Print(actedUponMessage)
+			continue
+		}
+		if action == "start" {
+			if instanceSchedulingTag == "skip-auto-start" {
+				RDSskippedInstances = append(RDSskippedInstances, *rdsInstance.DBInstanceIdentifier)
+				log.Print(skippedMessage)
+				continue
 			}
+			RDSinstancesActedUpon = append(RDSinstancesActedUpon, *rdsInstance.DBInstanceIdentifier)
+			startRDSInstance(rdsClient, *rdsInstance.DBInstanceIdentifier)
+			log.Print(actedUponMessage)
+			continue
+		}
+		if action == "test" {
+			if instanceSchedulingTag == "skip-auto-stop" || instanceSchedulingTag == "skip-auto-start" {
+				RDSskippedInstances = append(RDSskippedInstances, *rdsInstance.DBInstanceIdentifier)
+				log.Printf("Successfully tested skipping instance with Id %v\n", *rdsInstance.DBInstanceIdentifier)
+				continue
+			}
+			RDSinstancesActedUpon = append(RDSinstancesActedUpon, *rdsInstance.DBInstanceIdentifier)
+			log.Print(actedUponMessage)
+			continue
 		}
 	}
 

--- a/instance-scheduler/rds.go
+++ b/instance-scheduler/rds.go
@@ -128,7 +128,7 @@ func StopStartTestRDSInstancesInMemberAccount(RDSClient IRDSInstancesAPI, action
 			}
 
 			instancesActedUpon = append(instancesActedUpon, *RDSInstance.DBInstanceIdentifier)
-			log.Printf("INFO: Successfully tested RDS instance with DB instance identifier %v because instance-scheduling tag is absent\n")
+			log.Printf("INFO: Successfully tested RDS instance with DB instance identifier %v because instance-scheduling tag is absent\n", *RDSInstance.DBInstanceIdentifier)
 			continue
 		}
 
@@ -150,7 +150,7 @@ func parseRDSInstanceTags(instance rdstype.DBInstance, RDSskippedInstances []str
 			instanceSchedulingTag = *tag.Value
 		}
 		if *tag.Key == "instance-scheduling" && *tag.Value == "skip-scheduling" {
-			log.Printf("Skip instance because instance-scheduling tag having value 'skip-scheduling'\n")
+			log.Printf("INFO: Skip instance because instance-scheduling tag having value 'skip-scheduling'\n")
 			RDSskippedInstances = append(RDSskippedInstances, *instance.DBInstanceIdentifier)
 			isSkipSchedulingTag = true
 		}


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/modernisation-platform/issues/6687
- To decouple the responsibilities of the three separate processes: "start", "stop" and "test"

## ♻️ What's changed

- Refactored all logic related to starting RDS instances into the `startRDSInstances` function
- Refactored all logic related to stopping RDS instances into the `stopRDSInstances` function
- Refactored all logic related to testing RDS instances into the `testRDSInstances` function

## 📝 Notes

- The code currently is highly coupled at a technical level - this PR takes a step towards decoupling which better highlights the three current supported processes and allows the specific business logic of each process to shine through
- The changes implemented are non-functional, so won't affect how the current function operates - the changes just shift the logic around for readability (highlighted by the fact that no tests were needed to be changed for this PR ✅)