### PR TITLE
Add golang and provided:al2 base images

### DIFF
--- a/instance-scheduler/Dockerfile
+++ b/instance-scheduler/Dockerfile
@@ -1,14 +1,5 @@
 # Stage 1: Build the Go binary
-FROM public.ecr.aws/lambda/go:1 as builder
-
-# Install the specific version of Go
-ARG GO_VERSION=1.23.0
-RUN curl -sSL https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz | tar -C /usr/local -xz && \
-    ln -s /usr/local/go/bin/go /usr/local/bin/go && \
-    ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
-
-# Verify Go installation
-RUN echo "Go Version: $(go version)" && go version
+FROM golang:1.23 as builder
 
 # Copy the rest of the source code
 COPY . .
@@ -17,7 +8,7 @@ COPY . .
 RUN CGO_ENABLED=0 go build -o /instance-scheduler .
 
 # Stage 2: Create the final image
-FROM public.ecr.aws/lambda/go:1
+FROM public.ecr.aws/lambda/provided:al2
 
 # Copy the binary from the builder stage
 COPY --from=builder /instance-scheduler ${LAMBDA_TASK_ROOT}


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/8027

## How does this PR fix the problem?

A temporary fix was put in place to pin the golang version to 1.23 as dependabot updates had been breaking the build as the go version was not updating in tandem.

This PR removes the need to install go at the "builder" stage and instead uses golang base image to simplify the process.

It also replaces the base image of the final container with `lambda/provided:al2` as `lambda/go:1` is being deprecated. 

## How has this been tested?

Built container locally and running workflow/unit tests as part of this PR.