### PR TITLE
Add go cache-dependency-path

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -45,6 +45,7 @@ jobs:
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version: ">=1.18"
+          cache-dependency-path: "**/go.sum"
       - uses: aws-actions/setup-sam@2360ef6d90015369947b45b496193ab9976a9b04 # v2
       - name: SAM Validate
         run: |


### PR DESCRIPTION
## Issue

I noticed the `build-test-push.yml` workflow `setup-go` stage kept warning about the the following:

```
Warning: Restore cache failed: Dependencies file is not found in /home/runner/work/modernisation-platform-instance-scheduler/modernisation-platform-instance-scheduler. Supported file pattern: go.sum
```

## How it's being fixed

Following this suggestion: https://github.com/actions/setup-go/issues/427#issuecomment-1946115668

I've added a `cache-dependency-path` argument.

Build succeeded without the warning after this.