### PR TITLE
🐳  Update Dockerfile

### DIFF
--- a/instance-scheduler/Dockerfile
+++ b/instance-scheduler/Dockerfile
@@ -1,17 +1,28 @@
 # Stage 1: Build the Go binary
 FROM golang:1.23 as builder
 
+# Set the Go working directory
+WORKDIR /app
+
+# Copy and download dependency modules
+COPY go.mod go.sum ./
+RUN go mod download
+
 # Copy the rest of the source code
 COPY . .
 
 # Build the Go binary
-RUN CGO_ENABLED=0 go build -o /instance-scheduler .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /instance-scheduler .
 
 # Stage 2: Create the final image
 FROM public.ecr.aws/lambda/provided:al2
 
-# Copy the binary from the builder stage
-COPY --from=builder /instance-scheduler ${LAMBDA_TASK_ROOT}
+# Copy the binary and the bootstrap script from the builder stage
+COPY --from=builder /instance-scheduler ${LAMBDA_TASK_ROOT}/instance-scheduler
+COPY bootstrap ${LAMBDA_TASK_ROOT}/bootstrap
 
-# Set the CMD to the binary
-CMD [ "instance-scheduler" ]
+# Make the bootstrap script executable
+RUN chmod +x ${LAMBDA_TASK_ROOT}/bootstrap
+
+# Set the command for the Lambda runtime
+CMD [ "bootstrap" ]

--- a/instance-scheduler/Dockerfile
+++ b/instance-scheduler/Dockerfile
@@ -4,25 +4,17 @@ FROM golang:1.23 as builder
 # Set the Go working directory
 WORKDIR /app
 
-# Copy and download dependency modules
-COPY go.mod go.sum ./
-RUN go mod download
-
 # Copy the rest of the source code
 COPY . .
 
 # Build the Go binary
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /instance-scheduler .
+RUN CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -o /app/instance-scheduler .
 
-# Stage 2: Create the final image
-FROM public.ecr.aws/lambda/provided:al2
+# Stage 2: Create the final image with Lambda runtime
+FROM public.ecr.aws/lambda/provided:al2023
 
-# Copy the binary and the bootstrap script from the builder stage
-COPY --from=builder /instance-scheduler ${LAMBDA_TASK_ROOT}/instance-scheduler
-COPY bootstrap ${LAMBDA_TASK_ROOT}/bootstrap
+# Copy the built binary from the builder stage to the Lambda task root
+COPY --from=builder /app/instance-scheduler ${LAMBDA_TASK_ROOT}
 
-# Make the bootstrap script executable
-RUN chmod +x ${LAMBDA_TASK_ROOT}/bootstrap
-
-# Set the command for the Lambda runtime
-CMD [ "bootstrap" ]
+# Set the entry point for the Lambda runtime
+ENTRYPOINT [ "./instance-scheduler" ]


### PR DESCRIPTION
Currently our https://github.com/ministryofjustice/modernisation-platform-terraform-lambda-function is failing due to issues with the generated dockerfile (example workflow run [here](https://github.com/ministryofjustice/modernisation-platform-terraform-lambda-function) upon further investigation I can lamdba function is failing with the exit code 127 

```
{
  "errorType": "Runtime.ExitError",
  "errorMessage": "RequestId: 425ef427-c450-48b5-8073-4281fd7f98ef Error: Runtime exited with error: exit status 127"
}
```

further investigation has uncovered that it's an issue with the boostrap in the newly migrated `public.ecr.aws/lambda/provided:al` image (for reference: https://aws.amazon.com/cn/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/
```
/lambda-entrypoint.sh: line 14: /var/runtime/bootstrap: No such file or directory
INIT_REPORT Init Duration: 21.52 ms	Phase: init	Status: error	Error Type: Runtime.ExitError
/lambda-entrypoint.sh: line 14: /var/runtime/bootstrap: No such file or directory
INIT_REPORT Init Duration: 40.12 ms	Phase: invoke	Status: error	Error Type: Runtime.ExitError
START RequestId: 425ef427-c450-48b5-8073-4281fd7f98ef Version: $LATEST
RequestId: 425ef427-c450-48b5-8073-4281fd7f98ef Error: Runtime exited with error: exit status 127
Runtime.ExitError
END RequestId: 425ef427-c450-48b5-8073-4281fd7f98ef
REPORT RequestId: 425ef427-c450-48b5-8073-4281fd7f98ef	Duration: 104.80 ms	Billed Duration: 105 ms	Memory Size: 128 MB	Max Memory Used: 3 MB	
XRAY TraceId: 1-66fe6b31-530a950a6a2f9b1d22764de3	SegmentId: 3a579d480d1bdad0	Sampled: true	
```

This PR updates the Dockerfile and fixes the bootstrap 