### PR TITLE
Update Instance Scheduling Skip List to Include Missing Account

### DIFF
--- a/instance-scheduler/main_int_test.go
+++ b/instance-scheduler/main_int_test.go
@@ -14,7 +14,7 @@ func TestHandler(t *testing.T) {
 	t.Run("Test request", func(t *testing.T) {
 		// Accounts mi-platform-development and analytical-platform-data-development cause the main_int_test.go to fail because they are non-member accounts
 		// lacking the InstanceSchedulerAccess role, but they have the '-development' suffix typically present in member accounts.
-		os.Setenv("INSTANCE_SCHEDULING_SKIP_ACCOUNTS", "analytical-platform-data-development,analytical-platform-data-engineering-sandboxa,analytical-platform-development,bichard7-sandbox-a,bichard7-sandbox-b,bichard7-sandbox-c,bichard7-sandbox-shared,bichard7-shared,bichard7-test-current,bichard7-test-next,core-sandbox-dev,core-vpc-development,core-vpc-preproduction,core-vpc-sandbox,core-vpc-test,mi-platform-development,moj-network-operations-centre-preproduction,nomis-preproduction,opg-lpa-data-store-development,shared-services-dev")
+		os.Setenv("INSTANCE_SCHEDULING_SKIP_ACCOUNTS", "analytical-platform-data-development,analytical-platform-data-engineering-sandboxa,analytical-platform-development,bichard7-sandbox-a,bichard7-sandbox-b,bichard7-sandbox-c,bichard7-sandbox-shared,bichard7-shared,bichard7-test-current,bichard7-test-next,core-sandbox-dev,core-vpc-preproduction,core-vpc-sandbox,core-vpc-test,mi-platform-development,moj-network-operations-centre-preproduction,nomis-preproduction,opg-lpa-data-store-development,shared-services-dev")
 
 		instanceScheduler := InstanceScheduler{
 			LoadDefaultConfig:                        LoadDefaultConfig,
@@ -46,7 +46,6 @@ func TestHandler(t *testing.T) {
 		for _, accountName := range res.NonMemberAccountNames {
 			assert.False(t, strings.HasSuffix(accountName, "-production"), fmt.Sprintf("Production account %v was found in the list of non-member accounts. Production accounts should be skipped.", accountName))
 			if !strings.HasPrefix(accountName, "core-vpc-") {
-				fmt.Printf("Entering condition for: '%s'\n", accountName)
 				assert.False(t, strings.HasSuffix(accountName, "-development"), fmt.Sprintf("Non-member account %v was found with suffix '-development'. Accounts with such suffix are member accounts.", accountName))
 				assert.False(t, strings.HasSuffix(accountName, "-test"), fmt.Sprintf("Non-member account %v was found with suffix '-test'. Accounts with such suffix are member accounts.", accountName))
 				assert.False(t, strings.HasSuffix(accountName, "-preproduction"), fmt.Sprintf("Non-member account %v was found with suffix '-preproduction'. Accounts with such suffix are member accounts.", accountName))

--- a/instance-scheduler/main_int_test.go
+++ b/instance-scheduler/main_int_test.go
@@ -14,7 +14,7 @@ func TestHandler(t *testing.T) {
 	t.Run("Test request", func(t *testing.T) {
 		// Accounts mi-platform-development and analytical-platform-data-development cause the main_int_test.go to fail because they are non-member accounts
 		// lacking the InstanceSchedulerAccess role, but they have the '-development' suffix typically present in member accounts.
-		os.Setenv("INSTANCE_SCHEDULING_SKIP_ACCOUNTS", "analytical-platform-data-development,analytical-platform-data-engineering-sandboxa,analytical-platform-development,bichard7-sandbox-a,bichard7-sandbox-b,bichard7-sandbox-c,bichard7-sandbox-shared,bichard7-shared,bichard7-test-current,bichard7-test-next,core-sandbox-dev,core-vpc-preproduction,core-vpc-sandbox,core-vpc-test,mi-platform-development,moj-network-operations-centre-preproduction,nomis-preproduction,opg-lpa-data-store-development,shared-services-dev")
+		os.Setenv("INSTANCE_SCHEDULING_SKIP_ACCOUNTS", "analytical-platform-data-development,analytical-platform-data-engineering-sandboxa,analytical-platform-development,bichard7-sandbox-a,bichard7-sandbox-b,bichard7-sandbox-c,bichard7-sandbox-shared,bichard7-shared,bichard7-test-current,bichard7-test-next,core-sandbox-dev,core-vpc-development,core-vpc-preproduction,core-vpc-sandbox,core-vpc-test,mi-platform-development,moj-network-operations-centre-preproduction,nomis-preproduction,opg-lpa-data-store-development,shared-services-dev")
 
 		instanceScheduler := InstanceScheduler{
 			LoadDefaultConfig:                        LoadDefaultConfig,

--- a/instance-scheduler/main_int_test.go
+++ b/instance-scheduler/main_int_test.go
@@ -46,6 +46,7 @@ func TestHandler(t *testing.T) {
 		for _, accountName := range res.NonMemberAccountNames {
 			assert.False(t, strings.HasSuffix(accountName, "-production"), fmt.Sprintf("Production account %v was found in the list of non-member accounts. Production accounts should be skipped.", accountName))
 			if !strings.HasPrefix(accountName, "core-vpc-") {
+				fmt.Printf("Entering condition for: '%s'\n", accountName)
 				assert.False(t, strings.HasSuffix(accountName, "-development"), fmt.Sprintf("Non-member account %v was found with suffix '-development'. Accounts with such suffix are member accounts.", accountName))
 				assert.False(t, strings.HasSuffix(accountName, "-test"), fmt.Sprintf("Non-member account %v was found with suffix '-test'. Accounts with such suffix are member accounts.", accountName))
 				assert.False(t, strings.HasSuffix(accountName, "-preproduction"), fmt.Sprintf("Non-member account %v was found with suffix '-preproduction'. Accounts with such suffix are member accounts.", accountName))

--- a/instance-scheduler/utils.go
+++ b/instance-scheduler/utils.go
@@ -61,8 +61,10 @@ func getNonProductionAccounts(environments string, skipAccountNames string) map[
 	for _, record := range allAccounts {
 		if rec, ok := record.(map[string]interface{}); ok {
 			for key, val := range rec {
+				log.Printf("Checking account: %v", key)
 				// Skip if the account's name ends with "-production", for example: performance-hub-production will be skipped
-				if !strings.HasSuffix(key, "-production") && (len(skipAccountNames) < 1 || !strings.Contains(skipAccountNames, key)) {
+				if !strings.HasSuffix(key, "-production") && (len(skipAccountNames) < 1 || !strings.Contains(skipAccountNames, key)) || strings.HasPrefix(key, "core-vpc") {
+					log.Printf("Added account: %v", key)
 					accounts[key] = val.(string)
 				}
 			}

--- a/instance-scheduler/utils.go
+++ b/instance-scheduler/utils.go
@@ -63,7 +63,7 @@ func getNonProductionAccounts(environments string, skipAccountNames string) map[
 			for key, val := range rec {
 				log.Printf("Checking account: %v", key)
 				// Skip if the account's name ends with "-production", for example: performance-hub-production will be skipped
-				if !strings.HasSuffix(key, "-production") && (len(skipAccountNames) < 1 || !strings.Contains(skipAccountNames, key)) || strings.HasPrefix(key, "core-vpc") {
+				if !strings.HasSuffix(key, "-production") && (len(skipAccountNames) < 1 || !strings.Contains(skipAccountNames, key)) || !strings.HasPrefix(key, "core-vpc") {
 					log.Printf("Added account: %v", key)
 					accounts[key] = val.(string)
 				}


### PR DESCRIPTION
This PR updates the instance scheduling skip list by adding missing account that were causing the `InstanceSchedulerLambdaFunctionPolicy` role to fail in assuming the `InstanceSchedulerAccess` role.

By adding account to the skip list, we ensure that the scheduling process runs smoothly without triggering alarms in the **low-priority channel**

https://github.com/ministryofjustice/modernisation-platform/issues/8559
