### PR TITLE
Add Grouping to Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/instance-scheduler"
     schedule:
       interval: "daily"
+    groups:
+      gomod-dependencies:
+        patterns:
+          - "*"
     open-pull-requests-limit: 10
   - package-ecosystem: "docker"
     directory: "/instance-scheduler"
@@ -13,5 +17,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "daily"    
+    groups:
+      action-dependencies:
+        patterns:
+          - "*"
     open-pull-requests-limit: 10
+    


### PR DESCRIPTION
This PR updates the dependabot configuration to allow grouping for Github actions and Go dependencies. 