### PR TITLE
Adds dependabot cooldown feature

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/instance-scheduler"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     groups:
       gomod-dependencies:
         patterns:
@@ -13,11 +15,15 @@ updates:
     directory: "/instance-scheduler"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"    
+    cooldown:
+      default-days: 7
     groups:
       action-dependencies:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"    
+      interval: "daily"
     cooldown:
       default-days: 7
     groups:
@@ -29,4 +29,3 @@ updates:
         patterns:
           - "*"
     open-pull-requests-limit: 10
-    


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/12036

## How does this PR fix the problem?

Adds Dependabot cooldown configuration so newly released dependency versions must now wait 7 days by default before 
Dependabot raises a version-update PR 